### PR TITLE
Small bug in DirBrowser.py

### DIFF
--- a/Pmw/Pmw_2_0_1/contrib/DirBrowser.py
+++ b/Pmw/Pmw_2_0_1/contrib/DirBrowser.py
@@ -195,7 +195,10 @@ class DirBrowserDialog(Pmw.MegaToplevel):
 
         self.listbox.setlist(dirlist)
         pathlist = []
+        drives = [chr(x) + ":\\" for x in range(65,91) if os.path.exists(chr(x) + ":")]
         while path != '/':
+            if path in drives:
+                break
             pathlist.append(path)
             path = os.path.dirname(path)
         pathlist.append('/')


### PR DESCRIPTION
In `setpath()` function of `DirBrowserDialog` the while loop at the end, loops endlessly so I added an `if` and `break` statement with a `drives` variable for the base drive letters (the local disk ones on Windows).